### PR TITLE
Preemptive loading while scrolling upwards also

### DIFF
--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -80,16 +80,16 @@ var SGListView = React.createClass({
               ref={(row) => {
                 // Capture a reference to the cell on creation
                 // We have to do it this way for ListView: https://github.com/facebook/react-native/issues/897
-                PrvClassMethods.captureReferenceFor(this.cellData, sectionID, rowID, row);
+                PrivateMethods.captureReferenceFor(this.cellData, sectionID, rowID, row);
               }}/>
   },
 
   onChangeVisibleRows(visibleRows, changedRows) {
     // Update cell visibibility per the changedRows
-    PrvClassMethods.updateCellsVisibility(this.cellData, changedRows);
+    PrivateMethods.updateCellsVisibility(this.cellData, changedRows);
 
     // Premepty show rows to avoid onscreen flashes
-    PrvClassMethods.updateCellsPremptively(this.props, this.cellData, visibleRows);
+    PrivateMethods.updateCellsPremptively(this.props, this.cellData, visibleRows);
 
     // If the user supplied an onChangeVisibleRows function, then call it
     if (this.props.onChangeVisibleRows) {
@@ -105,9 +105,9 @@ var SGListView = React.createClass({
  * 3. They're static and hold 0 state
  * 4. Keeps the class size smaller
  */
-var PrvClassMethods = {
+var PrivateMethods = {
   captureReferenceFor: function(cellData, sectionId, rowId, row) {
-    if (cellData[sectionId] == undefined) {
+    if (cellData[sectionId] === undefined) {
       cellData[sectionId] = {};
     }
 
@@ -127,11 +127,8 @@ var PrvClassMethods = {
             var currentCell = cellData[section][row];
             var currentCellVisibility = currentSection[row];
 
-            // There's a possibility a cell was injected that isn't a JSCell
-            var isJSCell = currentCell != undefined && currentCell.setVisibility;
-
-            if (isJSCell) {
-              // Set the cell's new visibility state
+            // Set the cell's new visibility state
+            if (currentCell && currentCell.setVisibility) {
               currentCell.setVisibility(currentCellVisibility);
             }
           }
@@ -145,38 +142,85 @@ var PrvClassMethods = {
    * so the user doesn't see any flashing
    */
   updateCellsPremptively: function(props, cellData, visibleRows) {
-    if (props.premptiveLoading == false) {
+    if (!props.premptiveLoading) {
       return; // No need to run is preemptive loading is 0 or false
     }
 
-    // Quick and dirty way to get the last key in the object
+    if (!cellData.premptiveLoadedCells) {
+      cellData.premptiveLoadedCells = [];
+    };
+
+    // Get the first and last visible rows
+    var firstVisibleRow, lastVisibleRow, firstVisibleSection, lastVisibleSection;
     for (var section in visibleRows) {
-      for (var row in visibleRows[section]);
-    }
-    var lastRow = Number(row); // convert lastrow key to number
+      for (var row in visibleRows[section]) {
+        if (firstVisibleRow === undefined) {
+          firstVisibleSection = section;
+          firstVisibleRow = Number(row);
+        } else {
+          lastVisibleSection = section;
+          lastVisibleRow = Number(row);
+        }
+
+        /* 
+         * Dont consider a cell preemptiveloaded if it is touched by default visibility logic.
+         */
+        var currentCell = cellData[section][row];
+        if (cellData.premptiveLoadedCells) {
+          var i = cellData.premptiveLoadedCells.indexOf(currentCell);
+          if (i >= 0) {
+            cellData.premptiveLoadedCells.splice(i, 1);
+          }
+        };
+      };
+    };
 
     // Figure out if we're scrolling up or down
-    var isScrollingUp = cellData.lastVisibleRow > lastRow;
-    var isScrollingDown = cellData.lastVisibleRow < lastRow;
+    var isScrollingUp = cellData.firstVisibleRow > firstVisibleRow;
+    var isScrollingDown = cellData.lastVisibleRow < lastVisibleRow;
 
-    // Preemptivly set cells
+    var scrollDirectionChanged;
+    if (isScrollingUp && cellData.lastScrollDirection === 'down'){
+      scrollDirectionChanged = true;
+    } else if (isScrollingDown && cellData.lastScrollDirection === 'up') {
+      scrollDirectionChanged = true;
+    }
+
+    // remove the other side's preemptive cells
+    if (scrollDirectionChanged) {
+      var cell;
+      while(cell = cellData.premptiveLoadedCells.pop()) {
+        cell.setVisibility(false);
+      }
+    };
+
+    // Preemptively set cells
     for (var i = 1; i <= props.premptiveLoading; i++) {
       var cell;
 
       if (isScrollingUp){
-        cell = cellData[section][lastRow - i];
+        cell = cellData[firstVisibleSection][firstVisibleRow - i];
       } else if (isScrollingDown) {
-        cell = cellData[section][lastRow + i];
+        cell = cellData[lastVisibleSection][lastVisibleRow + i];
       }
 
       if (cell) {
         cell.setVisibility(true);
+        cellData.premptiveLoadedCells.push(cell);
       } else {
         break;
       }
     }
 
-    cellData.lastVisibleRow = lastRow; // cache the last seen row
+    cellData.firstVisibleRow = firstVisibleRow; // cache the first seen row
+    cellData.lastVisibleRow = lastVisibleRow; // cache the last seen row
+
+    if (isScrollingUp){
+      cellData.lastScrollDirection = 'up';
+    } else if (isScrollingDown) {
+      cellData.lastScrollDirection = 'down';
+    }
+    
   },
 };
 


### PR DESCRIPTION
And also fixes #4. Scrolling in one direction and then scrolling in another would leave some cells visible.
