### PR TITLE
Expose native ListView

### DIFF
--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -47,6 +47,10 @@ var SGListView = React.createClass({
     };
   },
 
+  getNativeListView() {
+    return this.refs.nativeListView;
+  },
+
   /**
    * Render Methods
    */
@@ -54,6 +58,7 @@ var SGListView = React.createClass({
   render: function() {
     return (
       <ListView {...this.props}
+        ref='nativeListView'
         renderScrollComponent={this.renderScrollComponent}
         renderRow={this.renderRow}
         onChangeVisibleRows={this.onChangeVisibleRows} />


### PR DESCRIPTION
This allows the user to access everything from the underlying `<ListView>`. 

Example this could be useful for:

``` js
import FastListView from 'react-native-sglistview';

class SomeComponent extends React.Component {
    componentWillReceiveProps(nextProps) {
        if (nextProps.foo !== this.props.foo) {
            // scroll to top
            this.refs.items
                .getNativeListView()
                .getScrollResponder()
                .scrollResponderScrollTo(0, 0);
        }
    }

    render() { 
        return <FastListView ref='items' ... />;
    }
}
```
