### PR TITLE
Improve handling of large rows

### DIFF
--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -195,8 +195,6 @@ var PrivateMethods = {
       isScrollingDown = true;
     }
     var isScrollingUp = !isScrollingDown;
-    var scrollDirectionChanged = (isScrollingUp && cellData.lastScrollDirection === 'down') ||
-                                 (isScrollingDown && cellData.lastScrollDirection === 'up');
 
     // Preemptively set new cells
     var newPremptiveCells = [];

--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -111,6 +111,16 @@ var SGListView = React.createClass({
  * 4. Keeps the class size smaller
  */
 var PrivateMethods = {
+  isItemInList: function(item, list) {
+    var found = false;
+    for(var i = 0 ; i < list.length ; i++) {
+      if(item === list[i]) {
+        found = true;
+        break;
+      }
+    }
+    return found;
+  },
   captureReferenceFor: function(cellData, sectionId, rowId, row) {
     if (cellData[sectionId] === undefined) {
       cellData[sectionId] = {};
@@ -151,14 +161,17 @@ var PrivateMethods = {
       return; // No need to run is preemptive loading is 0 or false
     }
 
-    if (!cellData.premptiveLoadedCells) {
-      cellData.premptiveLoadedCells = [];
+    if (!cellData.lastSetOfVisibileCells) {
+      cellData.lastSetOfVisibileCells = [];
     };
 
     // Get the first and last visible rows
     var firstVisibleRow, lastVisibleRow, firstVisibleSection, lastVisibleSection;
+    var visibleCells = [];
     for (var section in visibleRows) {
       for (var row in visibleRows[section]) {
+        visibleCells.push(cellData[section][row]);
+
         if (firstVisibleRow === undefined) {
           firstVisibleSection = section;
           firstVisibleRow = Number(row);
@@ -169,16 +182,6 @@ var PrivateMethods = {
           lastVisibleRow = Number(row);
         }
 
-        /*
-         * Dont consider a cell preemptiveloaded if it is touched by default visibility logic.
-         */
-        var currentCell = cellData[section][row];
-        if (cellData.premptiveLoadedCells) {
-          var i = cellData.premptiveLoadedCells.indexOf(currentCell);
-          if (i >= 0) {
-            cellData.premptiveLoadedCells.splice(i, 1);
-          }
-        };
       };
     };
 
@@ -195,31 +198,34 @@ var PrivateMethods = {
     var scrollDirectionChanged = (isScrollingUp && cellData.lastScrollDirection === 'down') ||
                                  (isScrollingDown && cellData.lastScrollDirection === 'up');
 
-    // remove the other side's preemptive cells
-    if (scrollDirectionChanged) {
-      var cell;
-      while(cell = cellData.premptiveLoadedCells.pop()) {
-        cell.setVisibility(false);
-      }
-    };
-
     // Preemptively set new cells
-    for (var i = 1; i <= (props.premptiveLoading - cellData.premptiveLoadedCells.length + 1); i++) {
+    var newPremptiveCells = [];
+    for (var i = 1; i <= props.premptiveLoading; i++) {
       var cell;
 
       if (isScrollingUp){
-        cell = cellData[firstVisibleSection][firstVisibleRow - i];
+        cell = cellData[firstVisibleSection] ? cellData[firstVisibleSection][firstVisibleRow - i] : null;
       } else if (isScrollingDown) {
-        cell = cellData[lastVisibleSection][lastVisibleRow + i];
+        cell = cellData[lastVisibleSection] ? cellData[lastVisibleSection][lastVisibleRow + i] : null;
       }
 
       if (cell) {
+        newPremptiveCells.push(cell);
         cell.setVisibility(true);
-        cellData.premptiveLoadedCells.push(cell);
       } else {
         break;
       }
     }
+
+    //Clean up anything in the old list that's not in the new list
+    while(cell = cellData.lastSetOfVisibileCells.pop()) {
+      if (!this.isItemInList(cell, newPremptiveCells) && !this.isItemInList(cell, visibleCells)) {
+        cell.setVisibility(false);
+      }
+    }
+
+    //Record our new set of premptive cells
+    cellData.lastSetOfVisibileCells = newPremptiveCells.concat(visibleCells);
 
     cellData.firstVisibleRow = firstVisibleRow; // cache the first seen row
     cellData.lastVisibleRow = lastVisibleRow; // cache the last seen row

--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -162,12 +162,14 @@ var PrivateMethods = {
         if (firstVisibleRow === undefined) {
           firstVisibleSection = section;
           firstVisibleRow = Number(row);
+          lastVisibleSection = section;
+          lastVisibleRow = Number(row);
         } else {
           lastVisibleSection = section;
           lastVisibleRow = Number(row);
         }
 
-        /* 
+        /*
          * Dont consider a cell preemptiveloaded if it is touched by default visibility logic.
          */
         var currentCell = cellData[section][row];
@@ -181,15 +183,17 @@ var PrivateMethods = {
     };
 
     // Figure out if we're scrolling up or down
-    var isScrollingUp = cellData.firstVisibleRow > firstVisibleRow;
-    var isScrollingDown = cellData.lastVisibleRow < lastVisibleRow;
+    // Start by taking the previous scroll direction.
+    var isScrollingDown = cellData.lastScrollDirection === 'down';
 
-    var scrollDirectionChanged;
-    if (isScrollingUp && cellData.lastScrollDirection === 'down'){
-      scrollDirectionChanged = true;
-    } else if (isScrollingDown && cellData.lastScrollDirection === 'up') {
-      scrollDirectionChanged = true;
+    //Did things move in the right direction?
+    //Or, if we're at the top, must be going down next...
+    if (cellData.firstVisibleRow < firstVisibleRow || firstVisibleRow === 0) {
+      isScrollingDown = true;
     }
+    var isScrollingUp = !isScrollingDown;
+    var scrollDirectionChanged = (isScrollingUp && cellData.lastScrollDirection === 'down') ||
+                                 (isScrollingDown && cellData.lastScrollDirection === 'up');
 
     // remove the other side's preemptive cells
     if (scrollDirectionChanged) {
@@ -199,8 +203,8 @@ var PrivateMethods = {
       }
     };
 
-    // Preemptively set cells
-    for (var i = 1; i <= props.premptiveLoading; i++) {
+    // Preemptively set new cells
+    for (var i = 1; i <= (props.premptiveLoading - cellData.premptiveLoadedCells.length + 1); i++) {
       var cell;
 
       if (isScrollingUp){
@@ -225,7 +229,7 @@ var PrivateMethods = {
     } else if (isScrollingDown) {
       cellData.lastScrollDirection = 'down';
     }
-    
+
   },
 };
 

--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -223,7 +223,7 @@ var PrivateMethods = {
     }
 
     //Record our new set of premptive cells
-    cellData.lastSetOfVisibileCells = newPremptiveCells.concat(visibleCells);
+    cellData.lastSetOfVisibileCells = newPremptiveCells; //.concat(visibleCells);
 
     cellData.firstVisibleRow = firstVisibleRow; // cache the first seen row
     cellData.lastVisibleRow = lastVisibleRow; // cache the last seen row

--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -185,35 +185,26 @@ var PrivateMethods = {
       };
     };
 
-    // Figure out if we're scrolling up or down
-    // Start by taking the previous scroll direction.
-    var isScrollingDown = cellData.lastScrollDirection === 'down';
-
-    //Did things move in the right direction?
-    //Or, if we're at the top, must be going down next...
-    if (cellData.firstVisibleRow < firstVisibleRow || firstVisibleRow === 0) {
-      isScrollingDown = true;
-    }
-    var isScrollingUp = !isScrollingDown;
-
-    // Preemptively set new cells
+    // Preemptively set new cells in each direction
     var newPremptiveCells = [];
-    for (var i = 1; i <= props.premptiveLoading; i++) {
-      var cell;
+    ['up', 'down'].forEach(dir => {
+      for (var i = 1; i <= props.premptiveLoading; i++) {
+        var cell;
 
-      if (isScrollingUp){
-        cell = cellData[firstVisibleSection] ? cellData[firstVisibleSection][firstVisibleRow - i] : null;
-      } else if (isScrollingDown) {
-        cell = cellData[lastVisibleSection] ? cellData[lastVisibleSection][lastVisibleRow + i] : null;
-      }
+        if (dir === 'up') {
+          cell = cellData[firstVisibleSection] ? cellData[firstVisibleSection][firstVisibleRow - i] : null;
+        } else if (dir === 'down') {
+          cell = cellData[lastVisibleSection] ? cellData[lastVisibleSection][lastVisibleRow + i] : null;
+        }
 
-      if (cell) {
-        newPremptiveCells.push(cell);
-        cell.setVisibility(true);
-      } else {
-        break;
+        if (cell) {
+          newPremptiveCells.push(cell);
+          cell.setVisibility(true);
+        } else {
+          break;
+        }
       }
-    }
+    });
 
     //Clean up anything in the old list that's not in the new list
     while(cell = cellData.lastSetOfVisibileCells.pop()) {
@@ -227,12 +218,6 @@ var PrivateMethods = {
 
     cellData.firstVisibleRow = firstVisibleRow; // cache the first seen row
     cellData.lastVisibleRow = lastVisibleRow; // cache the last seen row
-
-    if (isScrollingUp){
-      cellData.lastScrollDirection = 'up';
-    } else if (isScrollingDown) {
-      cellData.lastScrollDirection = 'down';
-    }
 
   },
 };

--- a/lib/SGListViewCell.js
+++ b/lib/SGListViewCell.js
@@ -21,6 +21,10 @@ var SGListViewCell = React.createClass({
     }
   },
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextState.visibility !== this.state.visibility;
+  },
+
   /**
    * View Lifecycle Methods
    */
@@ -60,10 +64,6 @@ var SGListViewCell = React.createClass({
    * View Management Methods
    */
   setVisibility(visibility) {
-    if (this.state.visibility == visibility) {
-      return; // already have the passed in state, so return early
-    }
-
     if (visibility == true) {
       this.setState({visibility: true});
     } else {


### PR DESCRIPTION
Our app has list items that are quite large and are often larger than the screen height.  In this case, it seems that the premptive loading was not functioning correctly, leading to lots of flickering and flashing.  

This PR attempts to better handle this case.  Performance in our case definitely seems improved, and I did some quick trials with smaller rows and they also seem to work well.  I do still see some flashing issues when scrolling up, not quite sure why though.  

Highlights:
- Assumes that things start scrolling down and adjusted scroll direction logic a bit.  
- Set lastVisibleSection & lastVisibleRow such that if there's only 1 visible item things aren't undefined.  
- Put a stronger cap on how many items are added to premptive list.  I saw that this list was ballooning out of control in some cases while testing (because when scrolling quickly the popping of visible elements wasn't catching everything?)

That's all I've got for now.  Hope this is helpful to some.  Thanks again for this great Component!!
