### PR TITLE
fix sliding bug

### DIFF
--- a/lib/SGListView.js
+++ b/lib/SGListView.js
@@ -21,7 +21,8 @@ const PrivateMethods = {
   /**
    * Go through the changed rows and update the cell with their new visibility state
    */
-  updateCellsVisibility(cellData, changedRows) {
+  updateCellsVisibility(cellData, visibleRows, changedRows) {
+    // update changed rows
     for (const section in changedRows) {
       if (changedRows.hasOwnProperty(section)) { // Good JS hygiene check
         const currentSection = changedRows[section];
@@ -34,6 +35,24 @@ const PrivateMethods = {
             // Set the cell's new visibility state
             if (currentCell && currentCell.setVisibility) {
               currentCell.setVisibility(currentCellVisibility);
+            }
+          }
+        }
+      }
+    }
+
+    // set visible rows visible, see https://github.com/sghiassy/react-native-sglistview/issues/12
+    for (const section in visibleRows) {
+      if (visibleRows.hasOwnProperty(section)) { // Good JS hygiene check
+        const currentSection = visibleRows[section];
+
+        for (const row in currentSection) {
+          if (currentSection.hasOwnProperty(row)) { // Good JS hygiene check
+            const currentCell = cellData[section][row];
+
+            // Set the cell visible
+            if (currentCell && currentCell.setVisibility) {
+              currentCell.setVisibility(true);
             }
           }
         }
@@ -183,7 +202,7 @@ const SGListView = React.createClass({
 
   onChangeVisibleRows(visibleRows, changedRows) {
     // Update cell visibibility per the changedRows
-    PrivateMethods.updateCellsVisibility(this.cellData, changedRows);
+    PrivateMethods.updateCellsVisibility(this.cellData, visibleRows, changedRows);
 
     // Premepty show rows to avoid onscreen flashes
     PrivateMethods.updateCellsPremptively(this.props, this.cellData, visibleRows);


### PR DESCRIPTION
Some unexpected blanks appear when sliding up rapidly. I set the visible rows' visibility explicitly to ensure all visible rows visible.
see https://github.com/sghiassy/react-native-sglistview/issues/12